### PR TITLE
feat: add workflow automation scripts for issue management

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -171,19 +171,6 @@ issueに対応するworktreeを作成します（setup-issue.sh から呼び出�
 - `issue-workflow` コマンドがインストールされていること（`full-workflow.sh` で使用）
 - GitHubへの認証が完了していること
 
-## 環境変数
-
-| 変数名 | 説明 | デフォルト |
-|--------|------|-----------|
-| `ISSUE_WORKFLOW_LANGUAGE` | 言語プリセット（`full-workflow.sh` で使用） | `generic` |
-
-利用可能な言語プリセット: `python`, `typescript`, `go`, `rust`, `generic`
-
-```bash
-# 例: Pythonプロジェクトでfull-workflowを実行
-ISSUE_WORKFLOW_LANGUAGE=python ./scripts/full-workflow.sh 199
-```
-
 ## 共通オプション
 
 すべてのスクリプトは以下の共通オプションをサポートしています:

--- a/scripts/complete-issue.sh
+++ b/scripts/complete-issue.sh
@@ -33,4 +33,6 @@ PROMPT="以下のスキルを実行してください:
 
 実装された変更をコミットし、リモートにプッシュして、プルリクエストを作成してください。"
 
-lib_run_claude "$PROMPT"
+if ! lib_run_claude "$PROMPT"; then
+    exit 1
+fi

--- a/scripts/full-workflow.sh
+++ b/scripts/full-workflow.sh
@@ -5,10 +5,6 @@
 # Example: ./scripts/full-workflow.sh 199
 # Example: ./scripts/full-workflow.sh -v 199
 #
-# 環境変数:
-#   ISSUE_WORKFLOW_LANGUAGE  言語プリセット（デフォルト: generic）
-#                            利用可能: python, typescript, go, rust, generic
-#
 # 以下を順次実行します:
 # 1. worktree作成 + start-issue（計画立案・実装）
 # 2. complete-issue（commit + push + PR作成）
@@ -24,20 +20,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT=$(lib_get_project_root)
 
-# 言語設定（環境変数から取得、デフォルトはgeneric）
-WORKFLOW_LANGUAGE="${ISSUE_WORKFLOW_LANGUAGE:-generic}"
-
 # オプション解析
 lib_parse_options "$@"
 set -- "${_LIB_REMAINING_ARGS[@]}"
 
 # ヘルプ表示
 if lib_should_show_help; then
-    lib_show_usage "full-workflow.sh" "issue対応の全ワークフローを自動実行" "<issue番号>" \
-"
-環境変数:
-  ISSUE_WORKFLOW_LANGUAGE  言語プリセット（デフォルト: generic）
-                           利用可能: python, typescript, go, rust, generic"
+    lib_show_usage "full-workflow.sh" "issue対応の全ワークフローを自動実行" "<issue番号>"
     exit 0
 fi
 
@@ -63,7 +52,6 @@ echo "🚀 Full Workflow: issue #${ISSUE_NUM}"
 if lib_is_verbose; then
     echo "   (verbose mode)"
 fi
-echo "   言語プリセット: $WORKFLOW_LANGUAGE"
 echo "═══════════════════════════════════════════════════════════════"
 echo ""
 
@@ -77,7 +65,10 @@ if [[ -n "$WORKTREE_PATH" ]]; then
     echo "📁 既存のワークツリーを検出: $WORKTREE_PATH"
 else
     echo "🔧 ワークツリーを作成中..."
-    "$SCRIPT_DIR/add-worktree.sh" "$ISSUE_NUM"
+    if ! "$SCRIPT_DIR/add-worktree.sh" "$ISSUE_NUM"; then
+        echo "⚠️ ワークツリーの作成に失敗しました" >&2
+        exit 1
+    fi
 
     WORKTREE_PATH=$(lib_get_worktree_path "$ISSUE_NUM")
 

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -41,4 +41,6 @@ echo ""
 
 PROMPT="/merge-pr $PR_NUM"
 
-lib_run_claude "$PROMPT"
+if ! lib_run_claude "$PROMPT"; then
+    exit 1
+fi

--- a/scripts/respond-comments.sh
+++ b/scripts/respond-comments.sh
@@ -34,4 +34,6 @@ echo ""
 
 PROMPT="/review-pr-comments $PR_NUM"
 
-lib_run_claude "$PROMPT"
+if ! lib_run_claude "$PROMPT"; then
+    exit 1
+fi

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -34,4 +34,6 @@ echo ""
 
 PROMPT="/pr-review-toolkit:review-pr $PR_NUM PRにコメントしてください"
 
-lib_run_claude "$PROMPT"
+if ! lib_run_claude "$PROMPT"; then
+    exit 1
+fi

--- a/scripts/setup-issue.sh
+++ b/scripts/setup-issue.sh
@@ -46,7 +46,10 @@ if [[ -n "$WORKTREE_PATH" ]]; then
 else
     # Step 2: add-worktree.sh を実行
     echo "🔧 ワークツリーを作成中..."
-    "$SCRIPT_DIR/add-worktree.sh" "$ISSUE_NUM"
+    if ! "$SCRIPT_DIR/add-worktree.sh" "$ISSUE_NUM"; then
+        echo "⚠️ ワークツリーの作成に失敗しました" >&2
+        exit 1
+    fi
 
     # Step 3: 作成されたディレクトリを検出
     WORKTREE_PATH=$(lib_get_worktree_path "$ISSUE_NUM")
@@ -81,4 +84,6 @@ ${CONTENT_REPLACED}"
 
 # worktreeディレクトリで claude -p を実行（自動化スクリプトのため常に --dangerously-skip-permissions）
 cd "$WORKTREE_PATH"
-exec claude -p "$PROMPT" --dangerously-skip-permissions
+if ! lib_run_claude "$PROMPT"; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add shell scripts to automate the complete issue-to-PR workflow
- Include `_lib.sh` shared library with common functions (dependency check, option parsing, PR detection, claude execution)
- Support verbose mode (`-v`) for debugging and progress visibility

## Scripts included
| Script | Purpose |
|--------|---------|
| `setup-issue.sh` | Create worktree and start issue planning |
| `complete-issue.sh` | Commit, push, and create PR |
| `review-pr.sh` | Review PR and post comments |
| `respond-comments.sh` | Respond to review comments |
| `merge-pr.sh` | Wait for CI and merge PR |
| `full-workflow.sh` | Execute entire workflow in one command |
| `add-worktree.sh` | Create issue-specific worktree |

## Test plan
- [ ] Run `./scripts/setup-issue.sh --help` to verify help output
- [ ] Run `./scripts/full-workflow.sh --help` to verify workflow documentation
- [ ] Test individual scripts with `-v` flag for verbose output

🤖 Generated with [Claude Code](https://claude.com/claude-code)