### PR TITLE
fix: preserve PIPESTATUS array before it gets overwritten

### DIFF
--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -278,10 +278,12 @@ lib_run_claude() {
         fi
 
         # パイプラインの終了コードを取得するためPIPESTATUSを使用
+        # 注意: PIPESTATUS配列は次のコマンドで上書きされるため、一度に保存する必要がある
         claude -p "$prompt" --dangerously-skip-permissions --output-format stream-json --verbose 2>&1 | \
             _lib_format_stream_json
-        local claude_exit=${PIPESTATUS[0]}
-        local jq_exit=${PIPESTATUS[1]}
+        local pipestatus=("${PIPESTATUS[@]}")
+        local claude_exit=${pipestatus[0]}
+        local jq_exit=${pipestatus[1]}
         if [[ $claude_exit -ne 0 ]]; then
             echo "⚠️ claudeの実行に失敗しました（終了コード: $claude_exit）" >&2
             return $claude_exit

--- a/scripts/add-worktree.sh
+++ b/scripts/add-worktree.sh
@@ -87,12 +87,16 @@ if lib_is_verbose; then
 
     claude -p "$PROMPT" --allowedTools "Bash(git:*),Bash(gh:*),Read,Glob" \
         --output-format stream-json --verbose 2>&1 | _lib_format_stream_json
-    claude_exit=${PIPESTATUS[0]}
-    jq_exit=${PIPESTATUS[1]}
+    # PIPESTATUS配列は次のコマンドで上書きされるため、一度に保存
+    pipestatus=("${PIPESTATUS[@]}")
+    claude_exit=${pipestatus[0]}
+    jq_exit=${pipestatus[1]}
     if [[ $claude_exit -ne 0 ]]; then
+        echo "⚠️ claudeの実行に失敗しました（終了コード: $claude_exit）" >&2
         exit $claude_exit
     fi
     if [[ $jq_exit -ne 0 ]]; then
+        echo "⚠️ 出力のフォーマットに失敗しました（終了コード: $jq_exit）" >&2
         exit $jq_exit
     fi
     exit 0


### PR DESCRIPTION
## Summary
- PIPESTATUS配列が後続のコマンドで上書きされる問題を修正
- パイプライン完了直後に配列全体を保存するように変更
- add-worktree.shにエラーメッセージを追加してデバッグを容易に

## Test plan
- [ ] `scripts/_lib.sh`のlib_run_claude関数でパイプラインエラーが正しく検出されることを確認
- [ ] `scripts/add-worktree.sh`でエラー時に適切なメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)