### PR TITLE
fix: update permission_denials type from list[str] to list[PermissionDenial]

### DIFF
--- a/src/claudecode_model/types.py
+++ b/src/claudecode_model/types.py
@@ -58,6 +58,8 @@ class PermissionDenial(BaseModel):
     tool_name: str
     tool_input: dict[str, JsonValue] | None = None
 
+    model_config = {"extra": "forbid"}
+
 
 class ModelUsageData(BaseModel):
     """Per-model usage data from CLI response.

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -137,6 +137,15 @@ class TestPermissionDenial:
         assert len(denial.tool_input["files"]) == 2  # type: ignore[arg-type]
         assert denial.tool_input["changes"][0]["line"] == 1  # type: ignore[index,call-overload]
 
+    def test_rejects_extra_fields(self) -> None:
+        """PermissionDenial should reject extra fields due to model_config."""
+        with pytest.raises(ValidationError):
+            PermissionDenial(
+                tool_name="Write",
+                tool_input={"file_path": "/test.txt"},
+                extra_field="not allowed",  # type: ignore[call-arg]
+            )
+
 
 class TestModelUsageData:
     """Tests for ModelUsageData model."""
@@ -546,8 +555,7 @@ class TestCLIResponse:
         assert response.permission_denials[1].tool_name == "Bash"
         assert response.permission_denials[1].tool_input is not None
         assert (
-            "sudo apt install"
-            in response.permission_denials[1].tool_input["command"]  # type: ignore[operator]
+            "sudo apt install" in response.permission_denials[1].tool_input["command"]  # type: ignore[operator]
         )
 
     def test_multiple_models_in_model_usage(self) -> None:


### PR DESCRIPTION
## Summary
- Claude Code CLI 2.1.11でpermission_denialsフィールドの形式が変更されたため型定義を更新
- `list[str]`から`list[PermissionDenial]`形式に対応

## Test plan
- [x] `TestPermissionDenial`クラスで新モデルの単体テスト（6テストケース）
- [x] `test_permission_denials_with_values`を新しいオブジェクト形式に更新
- [x] `test_parses_permission_denials_with_object_format`でJSONパースをテスト
- [x] `uv run pytest` - 157 passed
- [x] `uv run ruff check --fix .` - All checks passed
- [x] `uv run mypy .` - Success: no issues found

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)