### PR TITLE
feat: add tool_use_id field to PermissionDenial model

### DIFF
--- a/src/claudecode_model/types.py
+++ b/src/claudecode_model/types.py
@@ -55,7 +55,7 @@ class PermissionDenial(BaseModel):
     Represents a denied tool usage permission with the tool name, input, and ID.
     """
 
-    tool_name: str
+    tool_name: str = Field(min_length=1)
     tool_input: dict[str, JsonValue] | None = None
     tool_use_id: str | None = None
 
@@ -109,7 +109,7 @@ class PermissionDenialData(TypedDict, total=False):
 
     tool_name: str
     tool_input: dict[str, JsonValue]
-    tool_use_id: str
+    tool_use_id: str | None
 
 
 class ModelUsageDataDict(TypedDict, total=False):


### PR DESCRIPTION
## Summary
- Add optional `tool_use_id` field to `PermissionDenial` model to track the specific tool use that was denied
- Add corresponding field to `PermissionDenialData` TypedDict
- Add tests for the new field including backward compatibility

## Test plan
- [x] Unit tests for `PermissionDenial` with `tool_use_id`
- [x] Unit tests for backward compatibility without `tool_use_id`
- [x] Integration test for `parse_cli_response` with `tool_use_id` in permission_denials

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)