### PR TITLE
fix: add end-of-options marker to prevent dash-starting prompts from being interpreted as CLI options

### DIFF
--- a/src/claudecode_model/cli.py
+++ b/src/claudecode_model/cli.py
@@ -122,6 +122,7 @@ class ClaudeCodeCLI:
         if self.max_turns is not None:
             cmd.extend(["--max-turns", str(self.max_turns)])
 
+        cmd.append("--")  # End of options marker
         cmd.append(prompt)
         return cmd
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -242,6 +242,37 @@ class TestClaudeCodeCLIBuildCommand:
             assert "--max-turns" in cmd
             assert "5" in cmd
 
+    def test_builds_command_with_dash_starting_prompt(self) -> None:
+        """_build_command should handle prompts starting with dash."""
+        cli = ClaudeCodeCLI()
+        with patch("shutil.which", return_value="/usr/bin/claude"):
+            cmd = cli._build_command("-hello")
+            # Verify -- marker is present before the prompt
+            assert "--" in cmd
+            double_dash_index = cmd.index("--")
+            assert cmd[double_dash_index + 1] == "-hello"
+
+    def test_builds_command_with_triple_dash_starting_prompt(self) -> None:
+        """_build_command should handle prompts starting with triple dash (---)."""
+        cli = ClaudeCodeCLI()
+        with patch("shutil.which", return_value="/usr/bin/claude"):
+            cmd = cli._build_command("---test")
+            # Verify -- marker is present before the prompt
+            assert "--" in cmd
+            double_dash_index = cmd.index("--")
+            assert cmd[double_dash_index + 1] == "---test"
+
+    def test_builds_command_with_double_dash_starting_prompt(self) -> None:
+        """_build_command should handle prompts starting with double dash (--)."""
+        cli = ClaudeCodeCLI()
+        with patch("shutil.which", return_value="/usr/bin/claude"):
+            cmd = cli._build_command("--test")
+            # Verify end-of-options marker is present before the prompt
+            assert "--" in cmd
+            # The first "--" should be the marker, not part of the prompt
+            double_dash_index = cmd.index("--")
+            assert cmd[double_dash_index + 1] == "--test"
+
 
 class TestClaudeCodeCLIExecute:
     """Tests for ClaudeCodeCLI.execute method."""


### PR DESCRIPTION
## Summary
- Add `--` (end-of-options marker) before the prompt in `_build_command` to prevent prompts starting with dashes from being misinterpreted as CLI options
- Add tests for prompts starting with `-`, `--`, and `---`

## Test plan
- [x] Run `uv run pytest tests/test_cli.py -v` - all 41 tests pass
- [x] Run `uv run ruff check --fix . && uv run ruff format . && uv run mypy .` - all quality checks pass

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)