### PR TITLE
fix: support CLIResponse validation for --json-schema option

### DIFF
--- a/src/claudecode_model/cli.py
+++ b/src/claudecode_model/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import shutil
 
 from claudecode_model.exceptions import (
@@ -17,6 +18,8 @@ from claudecode_model.types import (
     JsonValue,
     parse_cli_response,
 )
+
+logger = logging.getLogger(__name__)
 
 # Constants
 DEFAULT_MODEL = "claude-sonnet-4-5"
@@ -245,6 +248,13 @@ class ClaudeCodeCLI:
                 stderr=response.result,
                 error_type="invalid_response",
                 recoverable=False,
+            )
+
+        # Log warning if errors are present (json-schema validation errors)
+        if response.errors:
+            logger.warning(
+                "CLI response contains validation errors (--json-schema mode): %s",
+                response.errors,
             )
 
         return response


### PR DESCRIPTION
## Summary
- Add default value `""` to `result` field in `CLIResponse` to handle json-schema mode where result may be missing
- Add optional `errors` field (`list[str] | None`) to `CLIResponse` and `CLIResponseData` TypedDict
- Add comprehensive tests for json-schema mode support (7 new tests)

## Background
When using `--json-schema` option, the CLI output format differs:
- `result` field may be missing or empty (structured data is in `structured_output`)
- `errors` field is present (list type) but was not defined in schema

This caused validation failures due to:
1. `result` being required but missing/empty
2. `errors` field being rejected by `extra="forbid"`

Fixes #29

## Test plan
- [x] Added `TestCLIResponseJsonSchemaMode` test class with 7 tests
- [x] All 221 tests pass
- [x] Quality checks pass (ruff check, ruff format, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)