### PR TITLE
fix: resolve auto output_mode to profile default in _extract_json_schema

### DIFF
--- a/src/claudecode_model/model.py
+++ b/src/claudecode_model/model.py
@@ -130,10 +130,19 @@ class ClaudeCodeModel(Model):
             model_request_parameters: Request parameters for tools and output.
 
         Returns:
-            JSON schema dict if output_mode is 'native' and output_object is set,
+            JSON schema dict if effective output_mode is 'native' and output_object is set,
             None otherwise.
+
+        Note:
+            When output_mode is 'auto', resolves to profile.default_structured_output_mode.
         """
-        if model_request_parameters.output_mode == "native":
+        output_mode = model_request_parameters.output_mode
+
+        # Resolve 'auto' mode using profile's default
+        if output_mode == "auto":
+            output_mode = self.profile.default_structured_output_mode
+
+        if output_mode == "native":
             if model_request_parameters.output_object is not None:
                 return model_request_parameters.output_object.json_schema
         return None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1311,3 +1311,113 @@ class TestClaudeCodeModelStructuredOutput:
             # Verify json_schema is passed to CLI
             call_kwargs = mock_cli_class.call_args.kwargs
             assert call_kwargs.get("json_schema") == json_schema
+
+
+class TestClaudeCodeModelExtractJsonSchema:
+    """Tests for ClaudeCodeModel._extract_json_schema method."""
+
+    def test_extract_json_schema_with_native_mode_returns_schema(self) -> None:
+        """_extract_json_schema should return schema when output_mode is native."""
+        from pydantic_ai.models import OutputObjectDefinition
+
+        model = ClaudeCodeModel()
+        json_schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+
+        params = ModelRequestParameters(
+            function_tools=[],
+            allow_text_output=True,
+            output_mode="native",
+            output_object=OutputObjectDefinition(
+                json_schema=json_schema,
+                name="TestOutput",
+                description="Test output",
+                strict=True,
+            ),
+        )
+
+        result = model._extract_json_schema(params)
+        assert result == json_schema
+
+    def test_extract_json_schema_with_native_mode_no_output_object_returns_none(
+        self,
+    ) -> None:
+        """_extract_json_schema should return None when output_mode is native but no output_object."""
+        model = ClaudeCodeModel()
+
+        params = ModelRequestParameters(
+            function_tools=[],
+            allow_text_output=True,
+            output_mode="native",
+            output_object=None,
+        )
+
+        result = model._extract_json_schema(params)
+        assert result is None
+
+    def test_extract_json_schema_with_tool_mode_returns_none(self) -> None:
+        """_extract_json_schema should return None when output_mode is tool."""
+        from pydantic_ai.models import OutputObjectDefinition
+
+        model = ClaudeCodeModel()
+        json_schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+
+        params = ModelRequestParameters(
+            function_tools=[],
+            allow_text_output=True,
+            output_mode="tool",
+            output_object=OutputObjectDefinition(
+                json_schema=json_schema,
+                name="TestOutput",
+                description="Test output",
+                strict=True,
+            ),
+        )
+
+        result = model._extract_json_schema(params)
+        assert result is None
+
+    def test_extract_json_schema_with_auto_mode_uses_profile_default(self) -> None:
+        """_extract_json_schema should use profile default when output_mode is auto.
+
+        When pydantic-ai Agent sets output_type, it calls with output_mode='auto'.
+        The model should resolve 'auto' to profile.default_structured_output_mode.
+        """
+        from pydantic_ai.models import OutputObjectDefinition
+
+        model = ClaudeCodeModel()
+        # Verify profile default is 'native'
+        assert model.profile.default_structured_output_mode == "native"
+
+        json_schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+
+        params = ModelRequestParameters(
+            function_tools=[],
+            allow_text_output=True,
+            output_mode="auto",
+            output_object=OutputObjectDefinition(
+                json_schema=json_schema,
+                name="TestOutput",
+                description="Test output",
+                strict=True,
+            ),
+        )
+
+        result = model._extract_json_schema(params)
+        # Should return schema because auto resolves to native
+        assert result == json_schema
+
+    def test_extract_json_schema_with_auto_mode_no_output_object_returns_none(
+        self,
+    ) -> None:
+        """_extract_json_schema should return None when output_mode is auto but no output_object."""
+        model = ClaudeCodeModel()
+
+        params = ModelRequestParameters(
+            function_tools=[],
+            allow_text_output=True,
+            output_mode="auto",
+            output_object=None,
+        )
+
+        result = model._extract_json_schema(params)
+        assert result is None


### PR DESCRIPTION
## Summary

- Fix `_extract_json_schema` to resolve `output_mode='auto'` to `profile.default_structured_output_mode`
- When pydantic-ai Agent sets `output_type`, it calls with `output_mode='auto'`, but previously the method only handled `'native'` mode explicitly
- Add comprehensive unit tests for `_extract_json_schema` method

## Test plan

- [x] Run `uv run pytest tests/test_model.py -v -k "extract_json_schema"` - 5 tests pass
- [x] Run `uv run pytest tests/test_model.py -v` - All 60 tests pass
- [x] Run `uv run ruff check --fix . && uv run ruff format . && uv run mypy .` - All checks pass

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)