### PR TITLE
feat: migrate ClaudeCodeModel from CLI subprocess to Claude Agent SDK

### DIFF
--- a/src/claudecode_model/cli.py
+++ b/src/claudecode_model/cli.py
@@ -26,6 +26,7 @@ DEFAULT_MODEL = "claude-sonnet-4-5"
 DEFAULT_TIMEOUT_SECONDS = 120.0
 MAX_PROMPT_LENGTH = 1_000_000  # 1MB limit
 DEFAULT_MAX_TURNS_WITH_JSON_SCHEMA = 3
+TIMEOUT_EXIT_CODE = -9  # Exit code for timeout signal (SIGKILL)
 
 
 class ClaudeCodeCLI:


### PR DESCRIPTION
## Summary
- Replace internal CLI subprocess execution with Claude Agent SDK's `query()` function
- Add `_build_agent_options()` method to convert parameters to `ClaudeAgentOptions`
- Add `_execute_sdk_query()` method with timeout handling via `anyio.move_on_after`
- Add `_result_message_to_cli_response()` method for backward compatibility with existing `CLIResponse` type
- Update all existing tests to mock SDK `query()` instead of `ClaudeCodeCLI`

## Test plan
- [x] Run `uv run pytest tests/test_model.py -v` (81 tests pass)
- [x] Run `uv run ruff check --fix . && uv run ruff format .`
- [x] Run `uv run mypy .`
- [ ] Manual integration test with actual Claude Agent SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)