### PR TITLE
feat: add tool_converter for pydantic-ai Tool to SDK MCP conversion

### DIFF
--- a/src/claudecode_model/__init__.py
+++ b/src/claudecode_model/__init__.py
@@ -21,6 +21,10 @@ from claudecode_model.response_converter import (
     extract_text_from_assistant_message,
 )
 from claudecode_model.tool_converter import (
+    JsonSchema,
+    McpResponse,
+    McpServerConfig,
+    McpTextContent,
     convert_tool,
     convert_tools_to_mcp_server,
 )
@@ -62,6 +66,10 @@ __all__ = [
     "extract_text_from_assistant_message",
     "convert_tool",
     "convert_tools_to_mcp_server",
+    "JsonSchema",
+    "McpResponse",
+    "McpServerConfig",
+    "McpTextContent",
 ]
 
 


### PR DESCRIPTION
## Summary
- Add `convert_tool` function to convert pydantic-ai Tool objects to Claude Agent SDK SdkMcpTool format
- Add `convert_tools_to_mcp_server` function to convert multiple tools with server configuration
- Include comprehensive test suite covering schema conversion, handler wrapping, and error handling

## Test plan
- [x] Run unit tests: `uv run pytest tests/test_tool_converter.py`
- [x] Verify type checking: `uv run mypy src/claudecode_model/tool_converter.py`
- [ ] Integration test with actual pydantic-ai agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)