### PR TITLE
feat: add MCP server integration for pydantic-ai toolsets

### DIFF
--- a/src/claudecode_model/mcp_integration.py
+++ b/src/claudecode_model/mcp_integration.py
@@ -6,6 +6,7 @@ Claude Agent SDK MCP server format.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Coroutine, Sequence
 from typing import Protocol, TypedDict, runtime_checkable
 
@@ -13,6 +14,8 @@ from claude_agent_sdk import SdkMcpTool, create_sdk_mcp_server, tool
 from claude_agent_sdk.types import McpSdkServerConfig
 
 from claudecode_model.types import JsonValue
+
+logger = logging.getLogger(__name__)
 
 
 class ToolDefinition(TypedDict):
@@ -26,11 +29,26 @@ class ToolDefinition(TypedDict):
 
 @runtime_checkable
 class PydanticAITool(Protocol):
-    """Protocol for pydantic-ai tool interface."""
+    """Protocol for pydantic-ai tool interface.
+
+    Attributes:
+        name: Tool name (must be non-empty).
+        description: Tool description.
+        parameters_json_schema: JSON schema for tool parameters.
+        function: Optional async callable that implements the tool logic.
+                  If not provided, the tool wrapper will raise an error.
+    """
 
     name: str
     description: str
     parameters_json_schema: dict[str, JsonValue]
+    function: Callable[..., Coroutine[object, object, object]] | None
+
+
+class ToolValidationError(ValueError):
+    """Error raised when tool validation fails."""
+
+    pass
 
 
 def extract_tools_from_toolsets(
@@ -43,12 +61,21 @@ def extract_tools_from_toolsets(
 
     Returns:
         List of tool definitions with name, description, and input_schema.
+
+    Raises:
+        ToolValidationError: If a tool has an empty name.
     """
     if toolsets is None:
         return []
 
     result: list[ToolDefinition] = []
     for t in toolsets:
+        # Validate tool name
+        if not t.name or not t.name.strip():
+            raise ToolValidationError(
+                "Tool name cannot be empty. Each tool must have a non-empty name."
+            )
+
         tool_def: ToolDefinition = {
             "name": t.name,
             "description": t.description,
@@ -59,6 +86,47 @@ def extract_tools_from_toolsets(
     return result
 
 
+ToolWrapperFunc = Callable[
+    [dict[str, object]], Coroutine[object, object, dict[str, object]]
+]
+
+
+def create_tool_wrapper(
+    tool_name: str,
+    original_function: Callable[..., Coroutine[object, object, object]],
+) -> ToolWrapperFunc:
+    """Create an async wrapper function for a pydantic-ai tool.
+
+    This function creates a wrapper that:
+    1. Calls the original function with provided arguments
+    2. Formats the result in MCP-compatible format
+    3. Logs and re-raises any exceptions
+
+    Args:
+        tool_name: Name of the tool (used for logging).
+        original_function: The async function to wrap.
+
+    Returns:
+        An async function that takes a dict of arguments and returns MCP-format response.
+    """
+
+    async def wrapper(args: dict[str, object]) -> dict[str, object]:
+        """Wrapper that delegates to original pydantic-ai tool function."""
+        try:
+            result = await original_function(**args)
+            return {"content": [{"type": "text", "text": str(result)}]}
+        except Exception as e:
+            logger.error(
+                "Tool '%s' execution failed: %s",
+                tool_name,
+                str(e),
+                exc_info=True,
+            )
+            raise
+
+    return wrapper
+
+
 def convert_tool_definition(tool_def: ToolDefinition) -> SdkMcpTool[dict[str, object]]:
     """Convert a tool definition to SdkMcpTool format.
 
@@ -67,35 +135,45 @@ def convert_tool_definition(tool_def: ToolDefinition) -> SdkMcpTool[dict[str, ob
 
     Returns:
         SdkMcpTool instance compatible with create_sdk_mcp_server.
+
+    Raises:
+        ToolValidationError: If the tool has no function registered.
     """
     original_function = tool_def.get("function")
+    tool_name = tool_def["name"]
 
-    @tool(tool_def["name"], tool_def["description"], tool_def["input_schema"])
-    async def wrapper(args: dict[str, object]) -> dict[str, object]:
-        """Wrapper that delegates to original pydantic-ai tool function."""
-        if original_function is not None:
-            # Call the original function with the args
-            result = await original_function(**args)
-            return {"content": [{"type": "text", "text": str(result)}]}
-        return {"content": [{"type": "text", "text": "No function registered"}]}
+    if original_function is None:
+        raise ToolValidationError(
+            f"Tool '{tool_name}' has no function registered. "
+            "Each tool must have a callable function."
+        )
 
-    return wrapper
+    wrapper = create_tool_wrapper(tool_name, original_function)
+
+    return tool(tool_name, tool_def["description"], tool_def["input_schema"])(wrapper)
+
+
+MCP_SERVER_NAME = "pydantic_tools"
 
 
 def create_mcp_server_from_tools(
-    name: str,
-    toolsets: Sequence[PydanticAITool] | None,
+    name: str = MCP_SERVER_NAME,
+    toolsets: Sequence[PydanticAITool] | None = None,
     version: str = "1.0.0",
 ) -> McpSdkServerConfig:
     """Create an MCP server from pydantic-ai toolsets.
 
     Args:
         name: Server name (used as prefix in mcp__<name>__<tool>).
+              Defaults to MCP_SERVER_NAME ("pydantic_tools").
         toolsets: Sequence of pydantic-ai tool objects.
         version: Server version string.
 
     Returns:
         McpSdkServerConfig for use with ClaudeAgentOptions.mcp_servers.
+
+    Raises:
+        ToolValidationError: If any tool has an empty name or no function.
     """
     tool_defs = extract_tools_from_toolsets(toolsets)
     sdk_tools = [convert_tool_definition(td) for td in tool_defs]

--- a/src/claudecode_model/model.py
+++ b/src/claudecode_model/model.py
@@ -28,6 +28,7 @@ from claudecode_model.cli import (
 )
 from claudecode_model.exceptions import CLIExecutionError
 from claudecode_model.mcp_integration import (
+    MCP_SERVER_NAME,
     PydanticAITool,
     create_mcp_server_from_tools,
 )
@@ -531,10 +532,20 @@ class ClaudeCodeModel(Model):
 
         Args:
             toolsets: Sequence of pydantic-ai tool objects or None.
+
+        Note:
+            Calling this method multiple times will overwrite the previous toolsets.
+            A warning is logged when overwriting existing toolsets.
         """
+        if MCP_SERVER_NAME in self._mcp_servers:
+            logger.warning(
+                "Overwriting existing MCP server '%s'. "
+                "Previous toolsets will be replaced.",
+                MCP_SERVER_NAME,
+            )
         self._agent_toolsets = toolsets
-        self._mcp_servers["pydantic_tools"] = create_mcp_server_from_tools(
-            name="pydantic-tools",
+        self._mcp_servers[MCP_SERVER_NAME] = create_mcp_server_from_tools(
+            name=MCP_SERVER_NAME,
             toolsets=toolsets,
         )
 

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -1,13 +1,17 @@
 """Tests for MCP integration with pydantic-ai toolsets."""
 
+import logging
 from unittest.mock import MagicMock
 
 import pytest
 
 from claudecode_model.mcp_integration import (
+    MCP_SERVER_NAME,
     ToolDefinition,
+    ToolValidationError,
     convert_tool_definition,
     create_mcp_server_from_tools,
+    create_tool_wrapper,
     extract_tools_from_toolsets,
 )
 
@@ -17,7 +21,7 @@ class TestExtractToolsFromToolsets:
 
     def test_extracts_tools_from_single_tool(self) -> None:
         """Should extract tool info from a single pydantic-ai tool."""
-        # pydantic-ai tool has name, description, and parameters_json_schema
+        # pydantic-ai tool has name, description, parameters_json_schema, and function
         mock_tool = MagicMock()
         mock_tool.name = "get_weather"
         mock_tool.description = "Get the current weather for a location"
@@ -26,6 +30,7 @@ class TestExtractToolsFromToolsets:
             "properties": {"location": {"type": "string", "description": "City name"}},
             "required": ["location"],
         }
+        mock_tool.function = None  # Optional function attribute
 
         result = extract_tools_from_toolsets([mock_tool])
 
@@ -39,6 +44,32 @@ class TestExtractToolsFromToolsets:
         location = properties.get("location")
         assert isinstance(location, dict)
         assert location.get("type") == "string"
+
+    def test_raises_on_empty_tool_name(self) -> None:
+        """Should raise ToolValidationError for empty tool name."""
+        mock_tool = MagicMock()
+        mock_tool.name = ""
+        mock_tool.description = "Description"
+        mock_tool.parameters_json_schema = {"type": "object", "properties": {}}
+        mock_tool.function = None
+
+        with pytest.raises(ToolValidationError) as exc_info:
+            extract_tools_from_toolsets([mock_tool])
+
+        assert "name cannot be empty" in str(exc_info.value)
+
+    def test_raises_on_whitespace_only_tool_name(self) -> None:
+        """Should raise ToolValidationError for whitespace-only tool name."""
+        mock_tool = MagicMock()
+        mock_tool.name = "   "
+        mock_tool.description = "Description"
+        mock_tool.parameters_json_schema = {"type": "object", "properties": {}}
+        mock_tool.function = None
+
+        with pytest.raises(ToolValidationError) as exc_info:
+            extract_tools_from_toolsets([mock_tool])
+
+        assert "name cannot be empty" in str(exc_info.value)
 
     def test_extracts_tools_from_multiple_tools(self) -> None:
         """Should extract tool info from multiple pydantic-ai tools."""
@@ -72,8 +103,8 @@ class TestExtractToolsFromToolsets:
 class TestConvertToolDefinition:
     """Tests for convert_tool_definition function."""
 
-    def test_converts_basic_tool(self) -> None:
-        """Should convert basic tool definition to SdkMcpTool format."""
+    def test_raises_on_missing_function(self) -> None:
+        """Should raise ToolValidationError when function is None."""
         tool_def: ToolDefinition = {
             "name": "search",
             "description": "Search for information",
@@ -85,6 +116,29 @@ class TestConvertToolDefinition:
             "function": None,
         }
 
+        with pytest.raises(ToolValidationError) as exc_info:
+            convert_tool_definition(tool_def)
+
+        assert "search" in str(exc_info.value)
+        assert "no function registered" in str(exc_info.value)
+
+    def test_converts_tool_with_function(self) -> None:
+        """Should convert tool definition with function to SdkMcpTool format."""
+
+        async def dummy_func(**kwargs: object) -> str:
+            return "result"
+
+        tool_def: ToolDefinition = {
+            "name": "search",
+            "description": "Search for information",
+            "input_schema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+            "function": dummy_func,
+        }
+
         result = convert_tool_definition(tool_def)
 
         # Should return a SdkMcpTool-compatible object
@@ -93,6 +147,10 @@ class TestConvertToolDefinition:
 
     def test_converts_tool_with_complex_schema(self) -> None:
         """Should convert tool with complex nested schema."""
+
+        async def dummy_func(**kwargs: object) -> str:
+            return "analyzed"
+
         tool_def: ToolDefinition = {
             "name": "analyze",
             "description": "Analyze data",
@@ -109,7 +167,7 @@ class TestConvertToolDefinition:
                     },
                 },
             },
-            "function": None,
+            "function": dummy_func,
         }
 
         result = convert_tool_definition(tool_def)
@@ -123,10 +181,15 @@ class TestCreateMcpServerFromTools:
 
     def test_creates_mcp_server_with_name(self) -> None:
         """Should create MCP server with specified name."""
+
+        async def dummy_func(**kwargs: object) -> str:
+            return "result"
+
         mock_tool = MagicMock()
         mock_tool.name = "test_tool"
         mock_tool.description = "A test tool"
         mock_tool.parameters_json_schema = {"type": "object", "properties": {}}
+        mock_tool.function = dummy_func
 
         result = create_mcp_server_from_tools(
             name="pydantic_tools", toolsets=[mock_tool]
@@ -137,10 +200,15 @@ class TestCreateMcpServerFromTools:
 
     def test_creates_mcp_server_with_version(self) -> None:
         """Should create MCP server with specified version."""
+
+        async def dummy_func(**kwargs: object) -> str:
+            return "result"
+
         mock_tool = MagicMock()
         mock_tool.name = "test_tool"
         mock_tool.description = "A test tool"
         mock_tool.parameters_json_schema = {"type": "object", "properties": {}}
+        mock_tool.function = dummy_func
 
         result = create_mcp_server_from_tools(
             name="pydantic_tools", toolsets=[mock_tool], version="2.0.0"
@@ -159,6 +227,14 @@ class TestCreateMcpServerFromTools:
         result = create_mcp_server_from_tools(name="none_tools", toolsets=None)
 
         assert result is not None
+
+    def test_uses_default_name(self) -> None:
+        """Should use MCP_SERVER_NAME as default name."""
+        result = create_mcp_server_from_tools()
+
+        assert result is not None
+        # Default name should be used
+        assert MCP_SERVER_NAME == "pydantic_tools"
 
 
 class TestMcpToolExecution:
@@ -197,6 +273,91 @@ class TestMcpToolExecution:
         assert sdk_tool is not None
 
 
+class TestCreateToolWrapper:
+    """Tests for create_tool_wrapper function (wrapper logic)."""
+
+    @pytest.mark.asyncio
+    async def test_wrapper_calls_original_function_with_args(self) -> None:
+        """Should call original function with provided arguments."""
+        call_log: list[str] = []
+
+        async def original_func(expression: str) -> str:
+            call_log.append(expression)
+            return f"Result: {expression}"
+
+        wrapper = create_tool_wrapper("calculator", original_func)
+        result = await wrapper({"expression": "2+2"})
+
+        assert call_log == ["2+2"]
+        assert result == {"content": [{"type": "text", "text": "Result: 2+2"}]}
+
+    @pytest.mark.asyncio
+    async def test_wrapper_handles_exception_with_logging(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Should log error when original function raises exception."""
+
+        async def failing_func(**kwargs: object) -> str:
+            raise ValueError("Test error")
+
+        wrapper = create_tool_wrapper("failing_tool", failing_func)
+
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(ValueError, match="Test error"):
+                await wrapper({})
+
+        assert "failing_tool" in caplog.text
+        assert "execution failed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_wrapper_returns_mcp_format_response(self) -> None:
+        """Should return MCP-format response with content array."""
+
+        async def simple_func() -> str:
+            return "Hello, World!"
+
+        wrapper = create_tool_wrapper("greeter", simple_func)
+        result = await wrapper({})
+
+        assert "content" in result
+        assert isinstance(result["content"], list)
+        assert len(result["content"]) == 1
+        assert result["content"][0]["type"] == "text"
+        assert result["content"][0]["text"] == "Hello, World!"
+
+    @pytest.mark.asyncio
+    async def test_wrapper_converts_result_to_string(self) -> None:
+        """Should convert non-string results to string."""
+
+        async def number_func() -> int:
+            return 42
+
+        wrapper = create_tool_wrapper("number_tool", number_func)
+        result = await wrapper({})
+
+        content = result["content"]
+        assert isinstance(content, list)
+        first_item = content[0]
+        assert isinstance(first_item, dict)
+        assert first_item["text"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_wrapper_passes_multiple_args(self) -> None:
+        """Should pass multiple arguments to original function."""
+        received_args: dict[str, object] = {}
+
+        async def multi_arg_func(a: int, b: str, c: bool) -> str:
+            received_args["a"] = a
+            received_args["b"] = b
+            received_args["c"] = c
+            return "done"
+
+        wrapper = create_tool_wrapper("multi_arg", multi_arg_func)
+        await wrapper({"a": 1, "b": "test", "c": True})
+
+        assert received_args == {"a": 1, "b": "test", "c": True}
+
+
 class TestToolNamePrefixing:
     """Tests for tool name prefixing (mcp__server__tool format)."""
 
@@ -206,10 +367,14 @@ class TestToolNamePrefixing:
         # as mcp__<server_name>__<tool_name>
         # This test verifies the naming pattern is maintained
 
+        async def dummy_func(**kwargs: object) -> str:
+            return "result"
+
         mock_tool = MagicMock()
         mock_tool.name = "search"
         mock_tool.description = "Search documents"
         mock_tool.parameters_json_schema = {"type": "object", "properties": {}}
+        mock_tool.function = dummy_func
 
         result = create_mcp_server_from_tools(
             name="pydantic_tools", toolsets=[mock_tool]
@@ -218,3 +383,11 @@ class TestToolNamePrefixing:
         # The server should be created successfully
         # The actual prefixing is handled by Claude Code CLI
         assert result is not None
+
+
+class TestMCPServerNameConstant:
+    """Tests for MCP_SERVER_NAME constant."""
+
+    def test_mcp_server_name_value(self) -> None:
+        """MCP_SERVER_NAME should have expected value."""
+        assert MCP_SERVER_NAME == "pydantic_tools"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2236,11 +2236,15 @@ class TestClaudeCodeModelSetAgentToolsets:
         """set_agent_toolsets should register toolsets internally."""
         from unittest.mock import MagicMock
 
+        async def dummy_func(**kwargs: object) -> str:
+            return "result"
+
         model = ClaudeCodeModel()
         mock_tool = MagicMock()
         mock_tool.name = "test_tool"
         mock_tool.description = "A test tool"
         mock_tool.parameters_json_schema = {"type": "object", "properties": {}}
+        mock_tool.function = dummy_func
 
         model.set_agent_toolsets([mock_tool])
 
@@ -2251,11 +2255,15 @@ class TestClaudeCodeModelSetAgentToolsets:
         """set_agent_toolsets should create MCP server from toolsets."""
         from unittest.mock import MagicMock
 
+        async def dummy_func(**kwargs: object) -> str:
+            return "result"
+
         model = ClaudeCodeModel()
         mock_tool = MagicMock()
         mock_tool.name = "search"
         mock_tool.description = "Search documents"
         mock_tool.parameters_json_schema = {"type": "object", "properties": {}}
+        mock_tool.function = dummy_func
 
         model.set_agent_toolsets([mock_tool])
 
@@ -2281,16 +2289,21 @@ class TestClaudeCodeModelSetAgentToolsets:
         """set_agent_toolsets should handle multiple tools."""
         from unittest.mock import MagicMock
 
+        async def dummy_func(**kwargs: object) -> str:
+            return "result"
+
         model = ClaudeCodeModel()
         mock_tool1 = MagicMock()
         mock_tool1.name = "tool1"
         mock_tool1.description = "Tool 1"
         mock_tool1.parameters_json_schema = {"type": "object", "properties": {}}
+        mock_tool1.function = dummy_func
 
         mock_tool2 = MagicMock()
         mock_tool2.name = "tool2"
         mock_tool2.description = "Tool 2"
         mock_tool2.parameters_json_schema = {"type": "object", "properties": {}}
+        mock_tool2.function = dummy_func
 
         model.set_agent_toolsets([mock_tool1, mock_tool2])
 
@@ -2301,13 +2314,41 @@ class TestClaudeCodeModelSetAgentToolsets:
         """get_mcp_servers should return registered MCP servers."""
         from unittest.mock import MagicMock
 
+        async def dummy_func(**kwargs: object) -> str:
+            return "result"
+
         model = ClaudeCodeModel()
         mock_tool = MagicMock()
         mock_tool.name = "test"
         mock_tool.description = "Test"
         mock_tool.parameters_json_schema = {"type": "object", "properties": {}}
+        mock_tool.function = dummy_func
 
         model.set_agent_toolsets([mock_tool])
 
         servers = model.get_mcp_servers()
         assert "pydantic_tools" in servers
+
+    def test_get_mcp_servers_returns_empty_dict_before_set_agent_toolsets(self) -> None:
+        """get_mcp_servers should return empty dict before set_agent_toolsets."""
+        model = ClaudeCodeModel()
+        servers = model.get_mcp_servers()
+        assert servers == {}
+
+    def test_set_agent_toolsets_logs_warning_on_overwrite(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """set_agent_toolsets should log warning when overwriting existing toolsets."""
+        import logging
+
+        model = ClaudeCodeModel()
+
+        # First call - no warning
+        model.set_agent_toolsets([])
+
+        # Second call - should log warning
+        with caplog.at_level(logging.WARNING):
+            model.set_agent_toolsets(None)
+
+        assert "Overwriting" in caplog.text
+        assert "pydantic_tools" in caplog.text


### PR DESCRIPTION
## Summary
- Add `set_agent_toolsets` method to `ClaudeCodeModel` for registering pydantic-ai tools as MCP servers
- Add `get_mcp_servers` method to retrieve registered MCP server configurations
- Add `mcp_integration` module with `create_mcp_server_from_tools` function for tool conversion

## Test plan
- [x] Test `set_agent_toolsets` registers toolsets internally
- [x] Test `set_agent_toolsets` creates MCP server from toolsets
- [x] Test `set_agent_toolsets` handles empty list
- [x] Test `set_agent_toolsets` handles None
- [x] Test `set_agent_toolsets` handles multiple tools
- [x] Test `get_mcp_servers` returns registered servers
- [x] Test `create_mcp_server_from_tools` with valid tools
- [x] Test `create_mcp_server_from_tools` with empty/None toolsets

🤖 Generated with [Claude Code](https://claude.com/claude-code)