### PR TITLE
fix: add JsonValue type annotation to json_schema in test_model_error

### DIFF
--- a/tests/test_model_error.py
+++ b/tests/test_model_error.py
@@ -14,6 +14,7 @@ from pydantic_ai.messages import (
 
 from claudecode_model.exceptions import CLIExecutionError, StructuredOutputError
 from claudecode_model.model import ClaudeCodeModel
+from claudecode_model.types import JsonValue
 
 
 class TestClaudeCodeModelIsErrorHandling:
@@ -301,7 +302,7 @@ class TestStructuredOutputError:
         ]
 
         # json_schema is required for recovery block to be entered
-        json_schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+        json_schema: dict[str, JsonValue] = {"type": "object", "properties": {"name": {"type": "string"}}}
 
         # Simulate SDK returning error_max_structured_output_retries
         error_result = ResultMessage(
@@ -341,7 +342,7 @@ class TestStructuredOutputError:
         ]
 
         # json_schema is required for recovery block to be entered
-        json_schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+        json_schema: dict[str, JsonValue] = {"type": "object", "properties": {"name": {"type": "string"}}}
 
         error_result = ResultMessage(
             subtype="error_max_structured_output_retries",


### PR DESCRIPTION
## Summary
- `test_model_error.py` の `json_schema` 変数に `dict[str, JsonValue]` の型注釈を追加
- mypy が nested dict literal を `dict[str, Collection[str]]` と推論し、`_execute_request` の `dict[str, JsonValue] | None` 引数と不一致になっていた問題を修正
- `JsonValue` 型を `claudecode_model.types` から import

## Test plan
- [x] `uv run mypy src tests example` で型エラーが解消されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)