### PR TITLE
fix: apply SDK message parser patch at module level to fix race condition

### DIFF
--- a/src/claudecode_model/_sdk_compat.py
+++ b/src/claudecode_model/_sdk_compat.py
@@ -5,9 +5,14 @@ message types (e.g., ``rate_limit_event``). Because the error occurs inside
 the SDK's async generator, it terminates the generator and loses subsequent
 messages including ``ResultMessage``.
 
-This module patches ``parse_message`` so that **only** unknown-type errors
-return ``None`` (skipped with a warning log). All other ``MessageParseError``
-cases (missing fields, malformed data) are re-raised as-is.
+This module patches ``parse_message`` at import time so that **only**
+unknown-type errors return ``None`` (skipped with a warning log). All other
+``MessageParseError`` cases (missing fields, malformed data) are re-raised
+as-is.
+
+The patch is applied once at module level (not per-call via a context
+manager) to avoid race conditions when multiple coroutines execute SDK
+queries concurrently via ``asyncio.TaskGroup``.
 
 **Policy note**: This is NOT a fallback — it is an explicit, logged skip of
 informational messages that are irrelevant to query results. The CLAUDE.md
@@ -22,12 +27,9 @@ Remove this module when upstream SDK handles unknown message types:
 from __future__ import annotations
 
 import logging
-from contextlib import contextmanager
-from collections.abc import Iterator
-
-from unittest.mock import patch
 
 from claude_agent_sdk._errors import MessageParseError
+import claude_agent_sdk._internal.client as _client_mod
 from claude_agent_sdk._internal.message_parser import (
     parse_message as _original_parse_message,
 )
@@ -76,30 +78,7 @@ def _safe_parse_message(data: dict[str, object]) -> Message | None:
         raise
 
 
-@contextmanager
-def safe_message_parsing() -> Iterator[None]:
-    """Context manager that patches parse_message to skip unknown message types.
-
-    Patches the ``parse_message`` reference in the SDK's client module so that
-    unknown message types return ``None`` instead of raising MessageParseError.
-    The caller must filter ``None`` values from the message stream.
-
-    Note:
-        The patch is applied via ``unittest.mock.patch`` as a temporary
-        workaround. This is acceptable because the entire module is
-        intended to be removed when the upstream SDK is fixed.
-
-    Usage::
-
-        with safe_message_parsing():
-            query_generator = query(prompt=prompt, options=options)
-            async for message in query_generator:
-                if message is None:
-                    continue
-                process(message)
-    """
-    with patch(
-        "claude_agent_sdk._internal.client.parse_message",
-        _safe_parse_message,
-    ):
-        yield
+# Apply patch once at module level. This replaces the parse_message reference
+# in the SDK's client module so that all SDK queries (including concurrent
+# ones via asyncio.TaskGroup) use _safe_parse_message.
+_client_mod.parse_message = _safe_parse_message  # type: ignore[assignment]


### PR DESCRIPTION
## Summary
Fixes issue #104 by replacing the context manager-based message parser patch with a module-level patch. The previous approach caused race conditions when multiple coroutines executed SDK queries concurrently via asyncio.TaskGroup - one coroutine exiting the context would restore the original parse_message while others were still running.

The patch is now applied once at module import time, ensuring all concurrent queries see the patched parse_message consistently.

## Changes
- Convert `safe_message_parsing()` context manager to module-level patch in `_sdk_compat.py`
- Remove unnecessary imports (contextlib, unittest.mock.patch)
- Update all callers in `model.py` to remove `with safe_message_parsing()` wrapper
- Add comprehensive concurrent safety tests using `asyncio.TaskGroup`

Closes #104

## Test plan
- All existing tests pass
- New `TestConcurrentSafety` tests verify the race condition is fixed
- Tests confirm patch persistence across concurrent coroutine completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)