### PR TITLE
feat: customizable MCP server name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,20 @@ print(result.output)
 - `CLIResponse`: Response data with metadata
 - `CLIUsage`: Token usage information
 
+### Agent Toolsets
+
+- `ClaudeCodeModel.set_agent_toolsets(toolsets, *, server_name="pydantic_tools")`: Register pydantic-ai tools as MCP server
+  - `server_name`: Customize the MCP server name (appears as `mcp__<server_name>__<tool_name>` in Claude Code CLI)
+
+```python
+model = ClaudeCodeModel()
+# Default: tools appear as mcp__pydantic_tools__<tool_name>
+model.set_agent_toolsets(tools)
+
+# Custom: tools appear as mcp__team__<tool_name>
+model.set_agent_toolsets(tools, server_name="team")
+```
+
 ### Tool Conversion
 
 - `convert_tool(tool)`: Convert pydantic-ai Tool to SdkMcpTool


### PR DESCRIPTION
## Summary
- Add `server_name` parameter to `set_agent_toolsets()` method for customizing MCP server naming
- Allows tools to appear as `mcp__<custom_name>__<tool_name>` instead of default `mcp__pydantic_tools__<tool_name>`
- Update internal state tracking with `_current_server_name` instance variable
- Comprehensive test coverage for custom naming, overwrite warnings, and SDK integration

## Test plan
- [x] Custom server name registers with correct key in `_mcp_servers`
- [x] Default server name uses 'pydantic_tools' when not specified
- [x] `_process_function_tools()` respects custom server name
- [x] Overwrite warning correctly references custom server name
- [x] `_build_agent_options()` includes custom server name in MCP servers
- [x] SDK integration passes custom server name through options
- [x] README documentation updated with usage examples

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)