### PR TITLE
feat: setup IPC protocol foundation for bridge communication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic-ai>=1.42.0",
     "claude-agent-sdk>=0.1.20",
     "dacite>=1.9.0",
+    "mcp>=1.0.0",
 ]
 
 [project.scripts]

--- a/src/claudecode_model/__init__.py
+++ b/src/claudecode_model/__init__.py
@@ -46,18 +46,24 @@ from claudecode_model.deps_support import (  # noqa: E402
     serialize_deps,
 )
 from claudecode_model.exceptions import (  # noqa: E402
+    BridgeStartupError,
     CLIExecutionError,
     CLIInterruptedError,
     CLINotFoundError,
     CLIResponseParseError,
     ClaudeCodeError,
     ErrorType,
+    IPCConnectionError,
+    IPCError,
+    IPCMessageSizeError,
+    IPCToolExecutionError,
     StructuredOutputError,
     ToolNotFoundError,
     ToolsetNotRegisteredError,
     TypeHintResolutionError,
     UnsupportedDepsTypeError,
 )
+from claudecode_model.ipc import DEFAULT_TRANSPORT, TransportType  # noqa: E402
 from claudecode_model.json_utils import extract_json  # noqa: E402
 from claudecode_model.model import ClaudeCodeModel  # noqa: E402
 from claudecode_model.response_converter import (  # noqa: E402
@@ -129,6 +135,15 @@ __all__ = [
     "McpResponse",
     "McpServerConfig",
     "McpTextContent",
+    # IPC bridge types
+    "TransportType",
+    "DEFAULT_TRANSPORT",
+    # IPC exceptions
+    "IPCError",
+    "IPCConnectionError",
+    "IPCMessageSizeError",
+    "IPCToolExecutionError",
+    "BridgeStartupError",
     # Serializable deps support (experimental)
     "DepsContext",
     "create_deps_context",

--- a/src/claudecode_model/exceptions.py
+++ b/src/claudecode_model/exceptions.py
@@ -156,6 +156,26 @@ class TypeHintResolutionError(ClaudeCodeError):
         self.original_error = original_error
 
 
+class IPCError(ClaudeCodeError):
+    """Base exception for IPC communication errors."""
+
+
+class IPCConnectionError(IPCError):
+    """Raised when the bridge process cannot connect to the IPC server."""
+
+
+class IPCMessageSizeError(IPCError):
+    """Raised when an IPC message exceeds MAX_MESSAGE_SIZE."""
+
+
+class IPCToolExecutionError(IPCError):
+    """Raised when a tool function raises an error during IPC execution."""
+
+
+class BridgeStartupError(IPCError):
+    """Raised when the bridge process fails to start."""
+
+
 class StructuredOutputError(ClaudeCodeError):
     """Raised when structured output extraction fails after maximum retries.
 

--- a/src/claudecode_model/ipc/__init__.py
+++ b/src/claudecode_model/ipc/__init__.py
@@ -1,0 +1,29 @@
+"""IPC bridge package for Claude Code CLI tool communication.
+
+This package provides the IPC (Inter-Process Communication) bridge mechanism
+that enables pydantic-ai tools registered via ``set_agent_toolsets()`` to be
+invoked through the Claude Code CLI, regardless of CLI version support for
+``type: "sdk"`` MCP servers.
+
+Architecture:
+    Parent Process (IPCServer) <-- Unix domain socket --> Bridge Process (MCP stdio)
+"""
+
+from typing import Literal
+
+type TransportType = Literal["auto", "stdio", "sdk"]
+"""Transport mode for tool communication.
+
+- ``"auto"``: Currently equivalent to ``"stdio"``. Will switch to ``"sdk"``
+  when CLI natively supports it.
+- ``"stdio"``: IPC bridge mode via Unix domain socket.
+- ``"sdk"``: Legacy SDK mode (``McpSdkServerConfig``).
+"""
+
+DEFAULT_TRANSPORT: TransportType = "auto"
+"""Default transport mode."""
+
+__all__ = [
+    "TransportType",
+    "DEFAULT_TRANSPORT",
+]

--- a/src/claudecode_model/ipc/protocol.py
+++ b/src/claudecode_model/ipc/protocol.py
@@ -1,0 +1,176 @@
+"""IPC protocol: message types, constants, and length-prefixed framing.
+
+This module defines the wire protocol between the parent process (IPC server)
+and the bridge process (MCP stdio server). Messages are JSON-encoded and
+transmitted over a Unix domain socket using length-prefixed framing.
+
+Wire format::
+
+    [4 bytes: payload length (big-endian uint32)][N bytes: UTF-8 JSON payload]
+"""
+
+import asyncio
+import json
+import struct
+from collections.abc import Mapping
+from typing import TypedDict
+
+from claudecode_model.exceptions import IPCError, IPCMessageSizeError
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+MAX_MESSAGE_SIZE: int = 10_485_760
+"""Maximum IPC message payload size in bytes (10 MB)."""
+
+LENGTH_PREFIX_SIZE: int = 4
+"""Byte count for the message length prefix (big-endian uint32)."""
+
+SOCKET_PERMISSIONS: int = 0o600
+"""Unix permission bits for socket files (owner read/write only)."""
+
+SOCKET_FILE_PREFIX: str = "claudecode_ipc_"
+"""Prefix for socket file names in the temp directory."""
+
+SOCKET_FILE_SUFFIX: str = ".sock"
+"""Suffix for socket file names."""
+
+SCHEMA_FILE_PREFIX: str = "claudecode_ipc_schema_"
+"""Prefix for tool schema temporary file names."""
+
+
+# ── Message TypedDicts ─────────────────────────────────────────────────────
+
+
+class CallToolParams(TypedDict):
+    """Parameters for a ``call_tool`` request."""
+
+    name: str
+    arguments: dict[str, object]
+
+
+class IPCRequest(TypedDict):
+    """Request message from bridge to parent (call_tool only)."""
+
+    method: str
+    params: CallToolParams
+
+
+class ToolResultContent(TypedDict):
+    """Single content block in a tool result (MCP TextContent)."""
+
+    type: str
+    text: str
+
+
+class _ToolResultRequired(TypedDict):
+    content: list[ToolResultContent]
+
+
+class ToolResult(_ToolResultRequired, total=False):
+    """Tool execution result (MCP CallToolResult compatible).
+
+    ``content`` is required; ``isError`` is optional (defaults to ``False``).
+    """
+
+    isError: bool
+
+
+class IPCResponse(TypedDict):
+    """Success response from parent to bridge."""
+
+    result: ToolResult
+
+
+class IPCErrorPayload(TypedDict):
+    """Error information on the wire (distinct from Python exception classes)."""
+
+    message: str
+    type: str
+
+
+class IPCErrorResponse(TypedDict):
+    """Error response from parent to bridge."""
+
+    error: IPCErrorPayload
+
+
+class ToolSchema(TypedDict):
+    """Tool schema passed to bridge process via temp file."""
+
+    name: str
+    description: str
+    input_schema: dict[str, object]
+
+
+# ── Length-prefixed framing ────────────────────────────────────────────────
+
+
+async def send_message(
+    writer: asyncio.StreamWriter,
+    message: Mapping[str, object],
+) -> None:
+    """Serialize *message* to JSON and send with a length prefix.
+
+    Args:
+        writer: An asyncio stream writer (e.g. from a Unix socket connection).
+        message: A JSON-serializable dictionary.
+
+    Raises:
+        IPCMessageSizeError: If the encoded payload exceeds ``MAX_MESSAGE_SIZE``.
+    """
+    payload = json.dumps(message).encode("utf-8")
+    if len(payload) > MAX_MESSAGE_SIZE:
+        raise IPCMessageSizeError(
+            f"Message size {len(payload)} bytes exceeds "
+            f"MAX_MESSAGE_SIZE ({MAX_MESSAGE_SIZE} bytes)"
+        )
+    prefix = struct.pack("!I", len(payload))
+    writer.write(prefix + payload)
+    await writer.drain()
+
+
+async def receive_message(
+    reader: asyncio.StreamReader,
+) -> dict[str, object]:
+    """Read a length-prefixed message and deserialize from JSON.
+
+    Args:
+        reader: An asyncio stream reader (e.g. from a Unix socket connection).
+
+    Returns:
+        The deserialized JSON object as a ``dict``.
+
+    Raises:
+        IPCError: If the stream ends prematurely or contains invalid JSON.
+        IPCMessageSizeError: If the declared payload length exceeds
+            ``MAX_MESSAGE_SIZE``.
+    """
+    try:
+        prefix = await reader.readexactly(LENGTH_PREFIX_SIZE)
+    except asyncio.IncompleteReadError as exc:
+        raise IPCError(
+            f"Incomplete length prefix: expected {LENGTH_PREFIX_SIZE} bytes, "
+            f"got {len(exc.partial)}"
+        ) from exc
+
+    (payload_length,) = struct.unpack("!I", prefix)
+    if payload_length > MAX_MESSAGE_SIZE:
+        raise IPCMessageSizeError(
+            f"Declared message size {payload_length} bytes exceeds "
+            f"MAX_MESSAGE_SIZE ({MAX_MESSAGE_SIZE} bytes)"
+        )
+
+    try:
+        payload = await reader.readexactly(payload_length)
+    except asyncio.IncompleteReadError as exc:
+        raise IPCError(
+            f"Incomplete payload: expected {payload_length} bytes, "
+            f"got {len(exc.partial)}"
+        ) from exc
+
+    try:
+        data: dict[str, object] = json.loads(payload.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise IPCError(f"Invalid JSON in IPC message: {exc}") from exc
+
+    return data

--- a/tests/test_ipc_protocol.py
+++ b/tests/test_ipc_protocol.py
@@ -1,0 +1,368 @@
+"""Tests for IPC protocol module.
+
+Tests cover:
+- Message TypedDict construction (IPCRequest, IPCResponse, IPCErrorResponse)
+- ToolSchema construction and JSON serialization round-trip
+- Length-prefix framing (send/receive round-trip)
+- MAX_MESSAGE_SIZE exceeded error
+- Empty message handling
+- Invalid JSON handling
+"""
+
+import asyncio
+import json
+import struct
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from claudecode_model.exceptions import IPCError, IPCMessageSizeError
+from claudecode_model.ipc.protocol import (
+    LENGTH_PREFIX_SIZE,
+    MAX_MESSAGE_SIZE,
+    SCHEMA_FILE_PREFIX,
+    SOCKET_FILE_PREFIX,
+    SOCKET_FILE_SUFFIX,
+    SOCKET_PERMISSIONS,
+    CallToolParams,
+    IPCErrorPayload,
+    IPCErrorResponse,
+    IPCRequest,
+    IPCResponse,
+    ToolResult,
+    ToolResultContent,
+    ToolSchema,
+    receive_message,
+    send_message,
+)
+
+
+class TestProtocolConstants:
+    """Test protocol constants are correctly defined."""
+
+    def test_max_message_size(self) -> None:
+        assert MAX_MESSAGE_SIZE == 10_485_760
+
+    def test_length_prefix_size(self) -> None:
+        assert LENGTH_PREFIX_SIZE == 4
+
+    def test_socket_permissions(self) -> None:
+        assert SOCKET_PERMISSIONS == 0o600
+
+    def test_socket_file_prefix(self) -> None:
+        assert SOCKET_FILE_PREFIX == "claudecode_ipc_"
+
+    def test_socket_file_suffix(self) -> None:
+        assert SOCKET_FILE_SUFFIX == ".sock"
+
+    def test_schema_file_prefix(self) -> None:
+        assert SCHEMA_FILE_PREFIX == "claudecode_ipc_schema_"
+
+
+class TestMessageTypedDicts:
+    """Test TypedDict construction for IPC messages."""
+
+    def test_ipc_request_construction(self) -> None:
+        params: CallToolParams = {"name": "my_tool", "arguments": {"key": "value"}}
+        request: IPCRequest = {"method": "call_tool", "params": params}
+
+        assert request["method"] == "call_tool"
+        assert request["params"]["name"] == "my_tool"
+        assert request["params"]["arguments"] == {"key": "value"}
+
+    def test_ipc_response_construction(self) -> None:
+        content: ToolResultContent = {"type": "text", "text": "result text"}
+        result: ToolResult = {"content": [content]}
+        response: IPCResponse = {"result": result}
+
+        assert response["result"]["content"][0]["type"] == "text"
+        assert response["result"]["content"][0]["text"] == "result text"
+
+    def test_ipc_response_with_is_error(self) -> None:
+        content: ToolResultContent = {"type": "text", "text": "error info"}
+        result: ToolResult = {"content": [content], "isError": True}
+        response: IPCResponse = {"result": result}
+
+        assert response["result"]["isError"] is True
+
+    def test_ipc_error_response_construction(self) -> None:
+        payload: IPCErrorPayload = {
+            "message": "Tool not found: unknown_tool",
+            "type": "ToolNotFoundError",
+        }
+        error_response: IPCErrorResponse = {"error": payload}
+
+        assert error_response["error"]["message"] == "Tool not found: unknown_tool"
+        assert error_response["error"]["type"] == "ToolNotFoundError"
+
+    def test_ipc_request_json_round_trip(self) -> None:
+        params: CallToolParams = {
+            "name": "calculator",
+            "arguments": {"expression": "2+2"},
+        }
+        request: IPCRequest = {"method": "call_tool", "params": params}
+
+        serialized = json.dumps(request)
+        deserialized = json.loads(serialized)
+
+        assert deserialized == request
+
+    def test_ipc_response_json_round_trip(self) -> None:
+        content: ToolResultContent = {"type": "text", "text": "4"}
+        result: ToolResult = {"content": [content], "isError": False}
+        response: IPCResponse = {"result": result}
+
+        serialized = json.dumps(response)
+        deserialized = json.loads(serialized)
+
+        assert deserialized == response
+
+    def test_ipc_error_response_json_round_trip(self) -> None:
+        payload: IPCErrorPayload = {
+            "message": "Division by zero",
+            "type": "ZeroDivisionError",
+        }
+        error_response: IPCErrorResponse = {"error": payload}
+
+        serialized = json.dumps(error_response)
+        deserialized = json.loads(serialized)
+
+        assert deserialized == error_response
+
+
+class TestToolSchema:
+    """Test ToolSchema construction and JSON serialization."""
+
+    def test_tool_schema_construction(self) -> None:
+        schema: ToolSchema = {
+            "name": "calculator",
+            "description": "Perform calculations",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "expression": {"type": "string"},
+                },
+                "required": ["expression"],
+            },
+        }
+
+        assert schema["name"] == "calculator"
+        assert schema["description"] == "Perform calculations"
+        assert schema["input_schema"]["type"] == "object"
+
+    def test_tool_schema_list_json_round_trip(self) -> None:
+        schemas: list[ToolSchema] = [
+            {
+                "name": "tool_a",
+                "description": "First tool",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"x": {"type": "integer"}},
+                },
+            },
+            {
+                "name": "tool_b",
+                "description": "Second tool",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"y": {"type": "string"}},
+                },
+            },
+        ]
+
+        serialized = json.dumps(schemas)
+        deserialized = json.loads(serialized)
+
+        assert len(deserialized) == 2
+        assert deserialized[0]["name"] == "tool_a"
+        assert deserialized[1]["name"] == "tool_b"
+        assert deserialized == schemas
+
+    def test_tool_schema_with_complex_input_schema(self) -> None:
+        schema: ToolSchema = {
+            "name": "complex_tool",
+            "description": "A tool with nested schema",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "nested": {
+                        "type": "object",
+                        "properties": {
+                            "items": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        serialized = json.dumps(schema)
+        deserialized = json.loads(serialized)
+        assert deserialized == schema
+
+
+def _create_mock_writer() -> tuple[MagicMock, bytearray]:
+    """Create a mock StreamWriter that captures written bytes."""
+    buffer = bytearray()
+    writer = MagicMock(spec=asyncio.StreamWriter)
+    writer.write = MagicMock(side_effect=lambda data: buffer.extend(data))
+    writer.drain = AsyncMock()
+    return writer, buffer
+
+
+def _create_reader_with_data(data: bytes) -> asyncio.StreamReader:
+    """Create a StreamReader pre-filled with data."""
+    reader = asyncio.StreamReader()
+    reader.feed_data(data)
+    reader.feed_eof()
+    return reader
+
+
+class TestLengthPrefixFraming:
+    """Test length-prefixed message framing (send/receive round-trip)."""
+
+    async def test_send_receive_round_trip(self) -> None:
+        message = {"method": "call_tool", "params": {"name": "test", "arguments": {}}}
+
+        writer, buffer = _create_mock_writer()
+        await send_message(writer, message)
+
+        reader = _create_reader_with_data(bytes(buffer))
+        received = await receive_message(reader)
+
+        assert received == message
+
+    async def test_send_message_format(self) -> None:
+        message = {"key": "value"}
+
+        writer, buffer = _create_mock_writer()
+        await send_message(writer, message)
+
+        payload = json.dumps(message).encode("utf-8")
+        expected_prefix = struct.pack("!I", len(payload))
+
+        assert bytes(buffer[:LENGTH_PREFIX_SIZE]) == expected_prefix
+        assert bytes(buffer[LENGTH_PREFIX_SIZE:]) == payload
+
+    async def test_receive_message_parses_json(self) -> None:
+        message = {"result": {"content": [{"type": "text", "text": "hello"}]}}
+        payload = json.dumps(message).encode("utf-8")
+        prefix = struct.pack("!I", len(payload))
+
+        reader = _create_reader_with_data(prefix + payload)
+        received = await receive_message(reader)
+
+        assert received == message
+
+    async def test_send_receive_multiple_messages(self) -> None:
+        messages: list[dict[str, object]] = [
+            {"method": "call_tool", "params": {"name": "a", "arguments": {}}},
+            {"result": {"content": [{"type": "text", "text": "ok"}]}},
+        ]
+
+        writer, buffer = _create_mock_writer()
+        for msg in messages:
+            await send_message(writer, msg)
+
+        reader = _create_reader_with_data(bytes(buffer))
+        received = []
+        for _ in messages:
+            received.append(await receive_message(reader))
+
+        assert received == messages
+
+    async def test_send_message_with_unicode(self) -> None:
+        message = {"text": "日本語テスト 🚀"}
+
+        writer, buffer = _create_mock_writer()
+        await send_message(writer, message)
+
+        reader = _create_reader_with_data(bytes(buffer))
+        received = await receive_message(reader)
+
+        assert received == message
+
+
+class TestMaxMessageSizeValidation:
+    """Test MAX_MESSAGE_SIZE exceeded error."""
+
+    async def test_send_message_exceeding_max_size_raises_error(self) -> None:
+        large_value = "x" * MAX_MESSAGE_SIZE
+        message = {"data": large_value}
+
+        writer, _ = _create_mock_writer()
+
+        with pytest.raises(IPCMessageSizeError):
+            await send_message(writer, message)
+
+    async def test_receive_message_with_oversized_length_prefix_raises_error(
+        self,
+    ) -> None:
+        oversized_length = MAX_MESSAGE_SIZE + 1
+        prefix = struct.pack("!I", oversized_length)
+        reader = _create_reader_with_data(prefix + b"x" * 10)
+
+        with pytest.raises(IPCMessageSizeError):
+            await receive_message(reader)
+
+    async def test_message_at_exact_max_size_succeeds(self) -> None:
+        # Create a message whose JSON payload is exactly MAX_MESSAGE_SIZE bytes
+        # We need to calculate the overhead of JSON encoding
+        base_message = {"d": ""}
+        base_overhead = len(json.dumps(base_message).encode("utf-8")) - 0
+        # Fill to exact limit
+        fill_size = MAX_MESSAGE_SIZE - base_overhead
+        message = {"d": "a" * fill_size}
+
+        # Verify it's exactly at the limit
+        payload = json.dumps(message).encode("utf-8")
+        assert len(payload) == MAX_MESSAGE_SIZE
+
+        writer, buffer = _create_mock_writer()
+        await send_message(writer, message)
+
+        reader = _create_reader_with_data(bytes(buffer))
+        received = await receive_message(reader)
+        assert received == message
+
+
+class TestEmptyMessageHandling:
+    """Test empty message handling."""
+
+    async def test_receive_empty_stream_raises_error(self) -> None:
+        reader = _create_reader_with_data(b"")
+
+        with pytest.raises(IPCError):
+            await receive_message(reader)
+
+    async def test_receive_incomplete_length_prefix_raises_error(self) -> None:
+        reader = _create_reader_with_data(b"\x00\x00")
+
+        with pytest.raises(IPCError):
+            await receive_message(reader)
+
+
+class TestInvalidJsonHandling:
+    """Test invalid JSON handling."""
+
+    async def test_receive_invalid_json_raises_error(self) -> None:
+        invalid_json = b"not valid json {{"
+        prefix = struct.pack("!I", len(invalid_json))
+
+        reader = _create_reader_with_data(prefix + invalid_json)
+
+        with pytest.raises(IPCError):
+            await receive_message(reader)
+
+    async def test_receive_truncated_payload_raises_error(self) -> None:
+        payload = json.dumps({"key": "value"}).encode("utf-8")
+        prefix = struct.pack("!I", len(payload))
+        # Send only half the payload
+        truncated = prefix + payload[: len(payload) // 2]
+
+        reader = _create_reader_with_data(truncated)
+
+        with pytest.raises(IPCError):
+            await receive_message(reader)

--- a/uv.lock
+++ b/uv.lock
@@ -364,6 +364,7 @@ source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },
     { name = "dacite" },
+    { name = "mcp" },
     { name = "pydantic-ai" },
 ]
 
@@ -379,6 +380,7 @@ dev = [
 requires-dist = [
     { name = "claude-agent-sdk", git = "https://github.com/drillan/claude-agent-sdk-python.git?branch=fix%2Fcombined-fixes" },
     { name = "dacite", specifier = ">=1.9.0" },
+    { name = "mcp", specifier = ">=1.0.0" },
     { name = "pydantic-ai", specifier = ">=1.42.0" },
 ]
 


### PR DESCRIPTION
## Summary
- Implement foundational IPC (Inter-Process Communication) components for bridge communication
- Add protocol layer with message serialization and transport abstraction
- Define IPC-specific exception types (IPCError, IPCConnectionError, IPCMessageSizeError, IPCToolExecutionError, BridgeStartupError)
- Include comprehensive protocol tests with 100% coverage

Closes #123

## Test plan
- Run existing test suite: `uv run pytest tests/test_ipc_protocol.py`
- Verify all IPC exception types are properly exported in `__init__.py`
- Check that protocol message serialization/deserialization works correctly
- Confirm TransportType and DEFAULT_TRANSPORT are accessible from package root

🤖 Generated with [Claude Code](https://claude.com/claude-code)