### PR TITLE
fix: break loop on ResultMessage to prevent blocking

### DIFF
--- a/src/claudecode_model/model.py
+++ b/src/claudecode_model/model.py
@@ -538,6 +538,7 @@ class ClaudeCodeModel(Model):
                         continue
                     if isinstance(message, ResultMessage):
                         result_message = message
+                        break
                     else:
                         # Capture StructuredOutput tool input from AssistantMessage.
                         # Note: If multiple StructuredOutput blocks exist, only the


### PR DESCRIPTION
## Summary
- Added `break` statement after capturing ResultMessage to terminate the async for loop in run_query()
- The generator was previously blocking until fully exhausted, causing delayed returns
- Successive error ResultMessages could overwrite successful results
- Comprehensive test suite covers loop termination scenarios

## Test plan
- TestResultMessageLoopTermination test class with 4 test cases:
  - First ResultMessage is correctly used when multiple are yielded
  - Structured output is preserved when error messages follow
  - Tool input from AssistantMessage is retained for recovery logic
  - Messages after ResultMessage don't trigger callbacks

All quality checks (ruff check, ruff format, mypy) already passed.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)