### PR TITLE
fix: resolve anyio CancelScope nesting conflict with pydantic-graph

### DIFF
--- a/tests/test_cancel_scope_fix.py
+++ b/tests/test_cancel_scope_fix.py
@@ -133,7 +133,7 @@ class TestCleanupQueryGeneratorOnTimeoutShielding:
 
         gen = OtherRuntimeErrorGenerator()
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.ERROR):
             with pytest.raises(CLIExecutionError) as exc_info:
                 await model._cleanup_query_generator_on_timeout(
                     gen._as_message_iterator(), timeout=5.0
@@ -145,7 +145,7 @@ class TestCleanupQueryGeneratorOnTimeoutShielding:
         assert any(
             "failed to close query generator" in record.message.lower()
             for record in caplog.records
-        ), "Should log warning about failed generator close"
+        ), "Should log error about failed generator close"
 
 
 class TestExecuteSdkQueryCancelScopeHandling:


### PR DESCRIPTION
## Summary
- Added defensive layers to prevent RuntimeError from anyio's cancel scope tree corruption
- Shield generator cleanup with CancelScope(shield=True) in _cleanup_query_generator_on_timeout()
- Handle RuntimeError in _execute_sdk_query() and stream_messages() with explicit exception propagation

Closes #142

## Test plan
- All 33 tests pass (9 new + 24 existing)
- New tests in `tests/test_cancel_scope_fix.py` cover all defense mechanisms
- Quality checks verified: ruff, mypy, pytest

🤖 Generated with [Claude Code](https://claude.com/claude-code)