### PR TITLE
fix: ensure query_generator cleanup on CancelScope error recovery

### DIFF
--- a/tests/test_model_sdk.py
+++ b/tests/test_model_sdk.py
@@ -678,7 +678,7 @@ class TestClaudeCodeModelTimeoutCleanup:
     async def test_execute_sdk_query_timeout_aclose_raises_exception(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """_execute_sdk_query should log warning when aclose() raises exception."""
+        """_execute_sdk_query should log error when aclose() raises RuntimeError."""
         model = ClaudeCodeModel()
         options = ClaudeAgentOptions()
 
@@ -700,7 +700,7 @@ class TestClaudeCodeModelTimeoutCleanup:
 
         import logging
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.ERROR):
             with patch("claudecode_model.model.query", mock_query):
                 with pytest.raises(CLIExecutionError) as exc_info:
                     await model._execute_sdk_query("Test prompt", options, timeout=0.1)
@@ -708,9 +708,9 @@ class TestClaudeCodeModelTimeoutCleanup:
         assert "timed out" in str(exc_info.value).lower()
         assert exc_info.value.error_type == "timeout"
         assert any(
-            "Failed to close query generator" in record.message
+            "RuntimeError during query generator cleanup" in record.message
             for record in caplog.records
-        ), "Should log warning when aclose() fails"
+        ), "Should log error when aclose() raises RuntimeError"
 
     @pytest.mark.asyncio
     async def test_execute_sdk_query_timeout_aclose_timeout(


### PR DESCRIPTION
## Summary
- Extract shared cleanup logic to `_cleanup_query_generator_safe()` method that handles CancelScope errors during generator closure
- Call cleanup explicitly after successful result preservation in `_execute_sdk_query` and `stream_messages` when CancelScope RuntimeError recovery succeeds
- Refactor `_cleanup_query_generator_on_timeout()` to reuse the new shared cleanup method
- Add 2 new test cases verifying cleanup handles CancelScope errors during aclose()
- Modify 2 existing test cases to track and verify aclose_called on preserved result paths

This fixes "Task exception was never retrieved" warnings that occur when garbage collection closes the generator in background contexts where CancelScope errors cannot be caught.

## Test plan
- [x] All existing tests pass (modified 2 tests to verify aclose_called)
- [x] 2 new tests added: verify cleanup with CancelScope error during aclose()
- [x] Type checking passes (mypy)
- [x] Code formatting passes (ruff format)
- [x] Linting passes (ruff check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)