### PR TITLE
refactor: upgrade to Python 3.13+ modern type syntax

### DIFF
--- a/src/claudecode_model/deps_support.py
+++ b/src/claudecode_model/deps_support.py
@@ -25,7 +25,7 @@ import json
 import logging
 from dataclasses import asdict, fields, is_dataclass
 from types import UnionType
-from typing import Generic, TypeVar, Union, get_args, get_origin, get_type_hints
+from typing import Union, get_args, get_origin, get_type_hints
 
 from dacite import from_dict
 from pydantic import BaseModel
@@ -36,8 +36,6 @@ from claudecode_model.exceptions import (
 )
 
 logger = logging.getLogger(__name__)
-
-T = TypeVar("T")
 
 # Primitive types that are directly JSON serializable
 _PRIMITIVE_TYPES: tuple[type, ...] = (str, int, float, bool, type(None))
@@ -197,7 +195,7 @@ def is_instance_serializable(obj: object) -> bool:
     if isinstance(obj, _PRIMITIVE_TYPES):
         return True
 
-    if isinstance(obj, (dict, list)):
+    if isinstance(obj, dict | list):
         return True
 
     if isinstance(obj, BaseModel):
@@ -209,7 +207,7 @@ def is_instance_serializable(obj: object) -> bool:
     return False
 
 
-def deserialize_deps(json_str: str, deps_type: type[T]) -> T:
+def deserialize_deps[T](json_str: str, deps_type: type[T]) -> T:
     """Deserialize JSON string to dependency object.
 
     Args:
@@ -244,7 +242,7 @@ def deserialize_deps(json_str: str, deps_type: type[T]) -> T:
     return data  # type: ignore[return-value]
 
 
-class DepsContext(Generic[T]):
+class DepsContext[T]:
     """Lightweight context for providing dependencies to tools.
 
     This class provides a simplified interface similar to pydantic-ai's
@@ -293,7 +291,7 @@ class DepsContext(Generic[T]):
         return self._deps
 
 
-def create_deps_context(deps: T) -> DepsContext[T]:
+def create_deps_context[T](deps: T) -> DepsContext[T]:
     """Create a DepsContext with the given dependencies.
 
     Args:

--- a/src/claudecode_model/model.py
+++ b/src/claudecode_model/model.py
@@ -383,7 +383,7 @@ class ClaudeCodeModel(Model):
 
         timeout_value = model_settings.get("timeout")
         if timeout_value is not None:
-            if isinstance(timeout_value, (int, float)):
+            if isinstance(timeout_value, int | float):
                 timeout = float(timeout_value)
             else:
                 logger.warning(
@@ -394,7 +394,7 @@ class ClaudeCodeModel(Model):
 
         max_budget_value = model_settings.get("max_budget_usd")
         if max_budget_value is not None:
-            if isinstance(max_budget_value, (int, float)):
+            if isinstance(max_budget_value, int | float):
                 max_budget_usd = float(max_budget_value)
                 if max_budget_usd < 0:
                     raise ValueError("max_budget_usd must be non-negative")

--- a/src/claudecode_model/response_converter.py
+++ b/src/claudecode_model/response_converter.py
@@ -39,7 +39,7 @@ def _safe_int(value: JsonValue, default: int = 0, *, field_name: str = "") -> in
     if isinstance(value, bool):
         # bool is subclass of int, but we want to treat True/False as 1/0
         return 1 if value else 0
-    if isinstance(value, (int, float)):
+    if isinstance(value, int | float):
         return int(value)
     if isinstance(value, str):
         try:

--- a/src/claudecode_model/tool_converter.py
+++ b/src/claudecode_model/tool_converter.py
@@ -15,14 +15,12 @@ import asyncio
 import json
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Literal, TypedDict, TypeVar
+from typing import Literal, TypedDict
 
 from claude_agent_sdk import SdkMcpTool
 from pydantic_ai.tools import Tool
 
 from claudecode_model.deps_support import DepsContext, create_deps_context
-
-T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +86,7 @@ def _format_return_value_as_mcp(result: object) -> McpResponse:
         text = ""
     elif isinstance(result, str):
         text = result
-    elif isinstance(result, (dict, list)):
+    elif isinstance(result, dict | list):
         text = json.dumps(result)
     else:
         text = str(result)
@@ -194,7 +192,7 @@ def convert_tool(tool: Tool[object]) -> SdkMcpTool[JsonSchema]:
     )
 
 
-def convert_tool_with_deps(tool: Tool[T], deps: T) -> SdkMcpTool[JsonSchema]:
+def convert_tool_with_deps[T](tool: Tool[T], deps: T) -> SdkMcpTool[JsonSchema]:
     """Convert a pydantic-ai Tool with dependencies to SdkMcpTool (experimental).
 
     This function enables tools that use RunContext to access serializable

--- a/tests/test_graceful_exit.py
+++ b/tests/test_graceful_exit.py
@@ -241,7 +241,7 @@ class TestGracefulTerminationConstants:
         """GRACEFUL_TERMINATION_TIMEOUT_SECONDS should be defined."""
         from claudecode_model.cli import GRACEFUL_TERMINATION_TIMEOUT_SECONDS
 
-        assert isinstance(GRACEFUL_TERMINATION_TIMEOUT_SECONDS, (int, float))
+        assert isinstance(GRACEFUL_TERMINATION_TIMEOUT_SECONDS, int | float)
         assert GRACEFUL_TERMINATION_TIMEOUT_SECONDS > 0
 
     def test_graceful_termination_timeout_value(self) -> None:


### PR DESCRIPTION
## Summary

Modernize type annotations across the codebase to leverage Python 3.13+ features:

- Replace `TypeVar` with PEP 695 type parameter syntax in `deps_support.py` and `tool_converter.py`
- Replace `isinstance(x, (A, B))` with `isinstance(x, A | B)` union syntax across 5 files
- Remove unused `Generic` and `TypeVar` imports

This improves code readability, reduces boilerplate, and aligns with Python 3.13+ best practices.

## Test plan

- [x] All 766 existing tests pass
- [x] Quality gates pass: ruff check, ruff format, mypy
- [x] No new linting or type errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)